### PR TITLE
Mobile nav fix

### DIFF
--- a/src/components/sections/MobileNav.tsx
+++ b/src/components/sections/MobileNav.tsx
@@ -4,9 +4,8 @@ import {IconArrow} from '~/components';
 import {EnhancedMenu, EnhancedMenuItem} from '~/lib/utils';
 // @ts-expect-error @headlessui/react incompatibility with node16 resolution
 import {Transition} from '@headlessui/react';
-import {useWindowSize, useSize} from 'react-use';
-
-import useIsomorphicLayoutEffect from '../../hooks/useIsomorphicLayoutEffect';
+import {useWindowSize, useMeasure, useSize} from 'react-use';
+import useIsomorphicLayoutEffect from '~/hooks/useIsomorphicLayoutEffect';
 
 export function MobileNav({
   isMobileOpen,
@@ -23,12 +22,7 @@ export function MobileNav({
   currentSubCollection: EnhancedMenuItem | null;
   setCurrentSubCollection: (i: EnhancedMenuItem | null) => void;
 }) {
-  // new
-  const mobileRef = useRef<any>(null);
-  const [height, setHeight] = useState<number>(0);
-
-  const [element, ref] = useState<HTMLElement | null>(null);
-  const [minHeight, setMinHeight] = useState<number>(0);
+  const [ref, {height}] = useMeasure();
 
   const toggleSubMenu = (item: EnhancedMenuItem) => {
     setCurrentSubCollection(item);
@@ -49,7 +43,6 @@ export function MobileNav({
 
   const untoggleSubMenu = () => {
     setCurrentSubCollection(null);
-    setMinHeight(height);
   };
 
   const themeText: any = {
@@ -57,39 +50,22 @@ export function MobileNav({
     suavecita: 'text-suave-pink',
   };
 
-  useIsomorphicLayoutEffect(() => {
-    if (!element) return;
-    setMinHeight(element.clientHeight);
-  }, [element]);
-
-  useIsomorphicLayoutEffect(() => {
-    if (mobileRef.current && isMobileOpen && height === 0) {
-      setHeight(mobileRef.current.clientHeight);
-    }
-  }, [mobileRef, height, isMobileOpen]);
-
-  // notes
-  // make main translate y set inside visible and get height htat way
-
   return (
-    <div
-      id="hello"
-      className={`${!isMobileOpen ? 'hidden' : ''}`}
-      ref={mobileRef}
-    >
+    <div className={`${!isMobileOpen ? 'hidden' : ''}`}>
       <Transition
         className={`md:hidden ${themeText[theme!]}`}
         style={{
-          minHeight: `${minHeight}px`,
+          minHeight: `${height}px`,
         }}
-        show={true}
-        // show={isMobileOpen}
+        show={isMobileOpen}
         enter="transform transition-all ease-in-out duration-300"
-        enterFrom="-translate-y-full opacity-0"
+        // enterFrom="-translate-y-full opacity-0"
+        enterFrom={`-translate-y-[${height}px] opacity-0`}
         enterTo="translate-y-0 opacity-100"
         leave="transform transition-all ease-in-out duration-300"
         leaveFrom="translate-y-0 opacity-100"
-        leaveTo="-translate-y-full opacity-0"
+        // leaveTo="-translate-y-full opacity-0"
+        leaveTo={`-translate-y-[${height}px] opacity-0`}
       >
         <Transition show={currentSubCollection !== null ? false : true}>
           <nav>

--- a/src/components/sections/MobileNav.tsx
+++ b/src/components/sections/MobileNav.tsx
@@ -59,13 +59,11 @@ export function MobileNav({
         }}
         show={isMobileOpen}
         enter="transform transition-all ease-in-out duration-300"
-        // enterFrom="-translate-y-full opacity-0"
-        enterFrom={`-translate-y-[${height}px] opacity-0`}
+        enterFrom="-translate-y-full opacity-0"
         enterTo="translate-y-0 opacity-100"
         leave="transform transition-all ease-in-out duration-300"
         leaveFrom="translate-y-0 opacity-100"
-        // leaveTo="-translate-y-full opacity-0"
-        leaveTo={`-translate-y-[${height}px] opacity-0`}
+        leaveTo="-translate-y-full opacity-0"
       >
         <Transition show={currentSubCollection !== null ? false : true}>
           <nav>

--- a/src/components/sections/ResponsiveBanner.tsx
+++ b/src/components/sections/ResponsiveBanner.tsx
@@ -38,7 +38,7 @@ export function ResponsiveBanner({
   return (
     <Link to={`/collections/${handle}`}>
       <section
-        className={`reponsive-banner relative justify-end flex flex-col w-full pb-[55px] ${
+        className={`reponsive-banner relative justify-end flex flex-col w-full pb-0 md:pb-[55px] ${
           top && '-mt-nav'
         }`}
       >

--- a/src/data/home-page-es.ts
+++ b/src/data/home-page-es.ts
@@ -315,7 +315,7 @@ export const featuredRowColumnsTwoSettings: FeaturedRowColumnsSectionData = {
       value: '',
       reference: {
         mediaContentType: 'IMAGE',
-        alt: 'This is my alt',
+        alt: 'Colaboraciones',
         previewImage: {
           url: 'https://cdn.shopify.com/s/files/1/0274/1389/files/suavecito-page-featured-image-5_720x.jpg?v=1632844585',
         },
@@ -340,7 +340,7 @@ export const featuredRowColumnsTwoSettings: FeaturedRowColumnsSectionData = {
       value: '',
       reference: {
         mediaContentType: 'IMAGE',
-        alt: 'This is my alt',
+        alt: 'Ropa',
         previewImage: {
           url: 'https://cdn.shopify.com/s/files/1/0274/1389/files/suavecito-page-featured-image-6_720x.jpg?v=1632844696',
         },
@@ -365,7 +365,7 @@ export const featuredRowColumnsTwoSettings: FeaturedRowColumnsSectionData = {
       value: '',
       reference: {
         mediaContentType: 'IMAGE',
-        alt: 'This is my alt',
+        alt: 'Coleccionables',
         previewImage: {
           url: 'https://cdn.shopify.com/s/files/1/0274/1389/files/suavecito-page-featured-image-7_720x.jpg?v=1632844657',
         },

--- a/src/hooks/useIsomorphicLayoutEffect.tsx
+++ b/src/hooks/useIsomorphicLayoutEffect.tsx
@@ -1,0 +1,7 @@
+import {useEffect, useLayoutEffect} from 'react';
+
+const isBrowser = typeof window !== 'undefined';
+
+const useIsomorphicLayoutEffect = isBrowser ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
# Changes
- Mobile Nav `jump` is better, might have to restructure mobile nav to translate sublists instead of completely remove them
- Fixed index text not matching between server & client, seemed to be the fault of alt tags, for w/e reason