### PR TITLE
Product Filtering By Tag

### DIFF
--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -8,3 +8,7 @@ export function getImageLoadingPriority(
 ) {
   return index < maxEagerLoadCount ? ATTR_LOADING_EAGER : undefined;
 }
+
+export const LANG = import.meta.env.PUBLIC_LANGUAGE_CODE;
+
+export const PRODUCT_FILTER_TAG: false | string = LANG ? 'hydrogen_es' : false;

--- a/src/routes/products/index.server.tsx
+++ b/src/routes/products/index.server.tsx
@@ -9,10 +9,15 @@ import {
 } from '@shopify/hydrogen';
 
 import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
-import {PAGINATION_SIZE} from '~/lib/const';
+import {PAGINATION_SIZE, PRODUCT_FILTER_TAG} from '~/lib/const';
 import {ProductGrid, PageHeader, Section} from '~/components';
 import {Layout} from '~/components/index.server';
 import type {Collection} from '@shopify/hydrogen/storefront-api-types';
+
+// if product filter tag set this will filter the collection by tag
+const PRODUCT_FILTER_QUERY: false | string = PRODUCT_FILTER_TAG
+  ? `tag:${PRODUCT_FILTER_TAG}`
+  : '';
 
 export default function AllProducts() {
   return (
@@ -40,6 +45,7 @@ function AllProductsGrid() {
       country: countryCode,
       language: languageCode,
       pageBy: PAGINATION_SIZE,
+      tagFilter: PRODUCT_FILTER_QUERY,
     },
     preload: true,
   });
@@ -80,6 +86,7 @@ export async function api(
       cursor,
       pageBy: PAGINATION_SIZE,
       country,
+      tagFilter: PRODUCT_FILTER_QUERY,
     },
   });
 }
@@ -91,8 +98,9 @@ const ALL_PRODUCTS_QUERY = gql`
     $language: LanguageCode
     $pageBy: Int!
     $cursor: String
+    $tagFilter: String
   ) @inContext(country: $country, language: $language) {
-    products(first: $pageBy, after: $cursor) {
+    products(first: $pageBy, after: $cursor, query: $tagFilter) {
       nodes {
         ...ProductCard
       }
@@ -112,8 +120,9 @@ const PAGINATE_ALL_PRODUCTS_QUERY = gql`
     $cursor: String
     $country: CountryCode
     $language: LanguageCode
+    $tagFilter: String
   ) @inContext(country: $country, language: $language) {
-    products(first: $pageBy, after: $cursor) {
+    products(first: $pageBy, after: $cursor, query: $tagFilter) {
       nodes {
         ...ProductCard
       }

--- a/src/routes/search.server.tsx
+++ b/src/routes/search.server.tsx
@@ -11,10 +11,8 @@ import {
 import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
 import {ProductGrid, Section, Text} from '~/components';
 import {SearchPage} from '~/components/index.server';
-import {PAGINATION_SIZE} from '~/lib/const';
+import {PAGINATION_SIZE, PRODUCT_FILTER_TAG} from '~/lib/const';
 import type {Collection} from '@shopify/hydrogen/storefront-api-types';
-
-const TAG = 'hydrogen_es';
 
 const search_page: {[key: string]: any} = {
   no_results: {
@@ -42,7 +40,9 @@ export default function Search({
 
   const searchTerm = searchParams.get('q');
 
-  const modifiedSearchTerm = `tag:${TAG} AND ${searchTerm}`;
+  const modifiedSearchTerm = PRODUCT_FILTER_TAG
+    ? `tag:${PRODUCT_FILTER_TAG} AND ${searchTerm}`
+    : searchTerm;
 
   const {data} = useShopQuery<any>({
     query: SEARCH_QUERY,
@@ -103,7 +103,9 @@ export async function api(
   const searchTerm = url.searchParams.get('q');
   const {handle} = params;
 
-  const modifiedSearchTerm = `tag:${TAG} AND ${searchTerm}`;
+  const modifiedSearchTerm = !PRODUCT_FILTER_TAG
+    ? `tag:${PRODUCT_FILTER_TAG} AND ${searchTerm}`
+    : searchTerm;
 
   return await queryShop({
     query: PAGINATE_SEARCH_QUERY,


### PR DESCRIPTION
# Changes
- Moved product filter tag to constants
- Updated collection/all route to filter products by said tag, since it uses a product query instead of a collection query. Product queries do not allow the filtering of products by metafield.